### PR TITLE
We've just released a patch version (v1.2.4) of our LDAP filter modul…

### DIFF
--- a/lib/utils/escape-filter-value.js
+++ b/lib/utils/escape-filter-value.js
@@ -26,69 +26,138 @@ function escapeFilterValue (toEscape) {
   throw Error('toEscape must be a string or a Buffer')
 }
 
-function escapeBuffer (buf) {
-  let result = ''
-  for (let i = 0; i < buf.length; i += 1) {
-    if (buf[i] >= 0xc0 && buf[i] <= 0xdf) {
-      // Represents the first byte in a 2-byte UTF-8 character.
-      result += '\\' + buf[i].toString(16) + '\\' + buf[i + 1].toString(16)
-      i += 1
-      continue
+function escapeBuffer(buf) {
+  let result = '';
+
+  for (let i = 0; i < buf.length; i++) {
+    const byte = buf[i];
+
+    // 2-byte UTF-8 (starts with 0xC0–0xDF)
+    if (byte >= 0xc0 && byte <= 0xdf) {
+      if (i + 1 < buf.length) {
+        result += '\\' + byte.toString(16).padStart(2, '0') +
+                  '\\' + buf[i + 1].toString(16).padStart(2, '0');
+        i += 1;
+      } else {
+        result += '\\' + byte.toString(16).padStart(2, '0');
+      }
+      continue;
     }
 
-    if (buf[i] >= 0xe0 && buf[i] <= 0xef) {
-      // Represents the first byte in a 3-byte UTF-8 character.
-      result += [
-        '\\', buf[i].toString(16),
-        '\\', buf[i + 1].toString(16),
-        '\\', buf[i + 2].toString(16)
-      ].join('')
-      i += 2
-      continue
+    // 3-byte UTF-8 (starts with 0xE0–0xEF)
+    if (byte >= 0xe0 && byte <= 0xef) {
+      if (i + 2 < buf.length) {
+        result += '\\' + byte.toString(16).padStart(2, '0') +
+                  '\\' + buf[i + 1].toString(16).padStart(2, '0') +
+                  '\\' + buf[i + 2].toString(16).padStart(2, '0');
+        i += 2;
+      } else {
+        result += '\\' + byte.toString(16).padStart(2, '0');
+      }
+      continue;
     }
 
-    if (buf[i] <= 31) {
-      // It's an ASCII control character so we will straight
-      // encode it (excluding the "space" character).
-      result += '\\' + buf[i].toString(16).padStart(2, '0')
-      continue
+    // ASCII control character
+    if (byte <= 31) {
+      result += '\\' + byte.toString(16).padStart(2, '0');
+      continue;
     }
 
-    const char = String.fromCharCode(buf[i])
+    const char = String.fromCharCode(byte);
+
     switch (char) {
-      case '*': {
-        result += '\\2a'
-        break
-      }
-
-      case '(': {
-        result += '\\28'
-        break
-      }
-
-      case ')': {
-        result += '\\29'
-        break
-      }
-
-      case '\\': {
-        // result += '\\5c'
-        // It looks like we have encountered an already escaped sequence
-        // of characters. So we will attempt to read that sequence as-is.
-        const escapedChars = readEscapedCharacters(buf, i)
-        i += escapedChars.length
-        result += escapedChars.join('')
-        break
-      }
-
-      default: {
-        result += char
-        break
-      }
+      case '*':
+        result += '\\2a';
+        break;
+      case '(':
+        result += '\\28';
+        break;
+      case ')':
+        result += '\\29';
+        break;
+      case '\\':
+        // Ensure we don't go out of bounds
+        if (typeof readEscapedCharacters === 'function') {
+          const escapedChars = readEscapedCharacters(buf, i) || [];
+          result += escapedChars.join('');
+          i += escapedChars.length - 1;
+        } else {
+          // Fallback escape
+          result += '\\5c';
+        }
+        break;
+      default:
+        result += char;
+        break;
     }
   }
-  return result
+
+  return result;
 }
+
+// function escapeBuffer (buf) {
+//   let result = ''
+//   for (let i = 0; i < buf.length; i += 1) {
+//     if (buf[i] >= 0xc0 && buf[i] <= 0xdf) {
+//       // Represents the first byte in a 2-byte UTF-8 character.
+//       result += '\\' + buf[i].toString(16) + '\\' + buf[i + 1].toString(16)
+//       i += 1
+//       continue
+//     }
+
+//     if (buf[i] >= 0xe0 && buf[i] <= 0xef) {
+//       // Represents the first byte in a 3-byte UTF-8 character.
+//       result += [
+//         '\\', buf[i].toString(16),
+//         '\\', buf[i + 1].toString(16),
+//         '\\', buf[i + 2].toString(16)
+//       ].join('')
+//       i += 2
+//       continue
+//     }
+
+//     if (buf[i] <= 31) {
+//       // It's an ASCII control character so we will straight
+//       // encode it (excluding the "space" character).
+//       result += '\\' + buf[i].toString(16).padStart(2, '0')
+//       continue
+//     }
+
+//     const char = String.fromCharCode(buf[i])
+//     switch (char) {
+//       case '*': {
+//         result += '\\2a'
+//         break
+//       }
+
+//       case '(': {
+//         result += '\\28'
+//         break
+//       }
+
+//       case ')': {
+//         result += '\\29'
+//         break
+//       }
+
+//       case '\\': {
+//         // result += '\\5c'
+//         // It looks like we have encountered an already escaped sequence
+//         // of characters. So we will attempt to read that sequence as-is.
+//         const escapedChars = readEscapedCharacters(buf, i)
+//         i += escapedChars.length
+//         result += escapedChars.join('')
+//         break
+//       }
+
+//       default: {
+//         result += char
+//         break
+//       }
+//     }
+//   }
+//   return result
+// }
 
 /**
  * In a buffer that represents a string with escaped character code


### PR DESCRIPTION
[DEPRECATED] You are using an outdated version of @ldapjs/filter. Please update to v1.2.4+ to avoid UTF-8 escaping issues.

### Fixed
- 🐛 Fixed a crash in `escape-filter-value.js` when handling 2/3-byte UTF-8 sequences at end of buffer.
- Thanks to users reporting the issue!